### PR TITLE
hal: use 0 as default return value for out_get_render_position

### DIFF
--- a/hal/audio_hw.c
+++ b/hal/audio_hw.c
@@ -1813,7 +1813,7 @@ static int out_get_render_position(const struct audio_stream_out *stream,
     struct stream_out *out = (struct stream_out *)stream;
     *dsp_frames = 0;
     if ((out->usecase == USECASE_AUDIO_PLAYBACK_OFFLOAD) && (dsp_frames != NULL)) {
-        ssize_t ret =  -EINVAL;
+        ssize_t ret = 0;
         pthread_mutex_lock(&out->lock);
         if (out->compr != NULL) {
             ret = compress_get_tstamp(out->compr, (unsigned long *)dsp_frames,


### PR DESCRIPTION
- Initialize default return value of out_get_render_position to
  0(NO_ERROR).
- Default value(NO_ERROR) will be used if timestamp query happens
  before compress driver is opened. Return 0(NO_ERROR) in this case
  to avoid playback failures.

Change-Id: I0f8b2e0f19cfe736a19934ddef18016599ec582c
CRs-Fixed: 756508
